### PR TITLE
feature: rocksdb minimal image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,10 @@
 version: 2.1
 
-
 executors:
   buildpack:
     docker:
       - image: circleci/buildpack-deps:trusty
     working_directory: ~/src
-
 
 commands:
   docker_import:
@@ -114,7 +112,6 @@ commands:
               docker push "$IMAGE_NAME:dev-$IMAGE_GIT"
             fi
 
-
 jobs:
   setup:
     executor: buildpack
@@ -165,6 +162,20 @@ jobs:
           <<: *persist_workspace
           paths:
             - docker/omisegoimages_elixir-omg_builder_elixir.tar
+
+  build_builder_rocksdb:
+    executor: buildpack
+    steps:
+      - setup_remote_docker
+      - attach_workspace: *attach_workspace
+      - docker_build:
+          image: "omisegoimages/elixir-omg-builder-rocksdb"
+          dockerfile: "builder/Dockerfile.rocksdb"
+          export: "~/docker/omisegoimages_elixir-omg_builder_rocksdb.tar"
+      - persist_to_workspace:
+          <<: *persist_workspace
+          paths:
+            - docker/omisegoimages_elixir-omg_builder_rocksdb.tar
 
   build_builder:
     executor: buildpack
@@ -248,7 +259,6 @@ jobs:
           paths:
             - ~/docker
 
-
 workflows:
   version: 2
   build:
@@ -261,14 +271,20 @@ workflows:
       - build_builder_elixir:
           requires:
             - build_builder_erlang
+      - build_builder_rocksdb:
+          requires:
+            - setup
       - build_builder:
           requires:
+            - build_builder_rocksdb
             - build_builder_elixir
       - publish_builder:
           requires:
             - build_builder
+
       - build_tester:
           requires:
+            - build_builder_rocksdb
             - build_builder_elixir
       - publish_tester:
           requires:

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -11,9 +11,16 @@ ARG GID=10000
 COPY --from=omisegoimages/elixir-omg-builder-erlang /usr/local/otp /usr/local/otp
 COPY --from=omisegoimages/elixir-omg-builder-erlang /usr/local/rebar3 /usr/local/rebar3
 COPY --from=omisegoimages/elixir-omg-builder-elixir /usr/local/elixir /usr/local/elixir
+COPY --from=omisegoimages/elixir-omg-builder-rocksdb /usr/local/rocksdb /usr/local/rocksdb
 
 ENV LD_LIBRARY_PATH=/usr/local/otp/lib:$LD_LIBRARY_PATH
 ENV LD_LIBRARY_PATH=/usr/local/elixir/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=/usr/local/rocksdb/lib:$LD_LIBRARY_PATH
+
+ENV CMAKE_PREFIX_PATH=/usr/local/otp:$CMAKE_PREFIX_PATH
+ENV CMAKE_PREFIX_PATH=/usr/local/elixir:$CMAKE_PREFIX_PATH
+ENV CMAKE_PREFIX_PATH=/usr/local/rocksdb:$CMAKE_PREFIX_PATH
+
 ENV PATH=/usr/local/otp/bin:$PATH
 ENV PATH=/usr/local/rebar3/bin:$PATH
 ENV PATH=/usr/local/elixir/bin:$PATH
@@ -21,11 +28,6 @@ ENV PATH=/usr/local/elixir/bin:$PATH
 ENV HOME /home/${USER}
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
-
-RUN wget https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
-  && chmod +x solc-static-linux \
-  && mv solc-static-linux solc  \
-  && install -m0755 solc /usr/local/bin/solc
 
 RUN set -xe \
  && apk add --update --no-cache --virtual .utils \
@@ -66,21 +68,15 @@ RUN set -xe \
  && mkdir -p "${HOME}" \
  && chown -R "${UID}:${GID}" "${HOME}"
 
-RUN cd /tmp && \
-    git clone https://github.com/facebook/rocksdb.git && \
-    cd rocksdb && \
-    git checkout v6.2.2 && \
-    make shared_lib && \
-    mkdir -p /usr/local/rocksdb/lib && \
-    mkdir /usr/local/rocksdb/include && \
-    cp librocksdb.so* /usr/local/rocksdb/lib && \
-    cp /usr/local/rocksdb/lib/librocksdb.so* /usr/lib/ && \
-    cp -r include /usr/local/rocksdb/ && \
-    cp -r include/* /usr/include/ && \
-    rm -R /tmp/rocksdb/
+RUN set -xe \
+  && cd /tmp \
+  && curl -fsL -o solc https://github.com/ethereum/solidity/releases/download/v0.4.25/solc-static-linux \
+  && chmod +x solc \
+  && install -m0755 solc /usr/local/bin/solc \
+  && scanelf --nobanner -E ET_EXEC -BF '%F' /usr/local/bin/solc | xargs -r strip --strip-all \
+  && scanelf --nobanner -E ET_DYN -BF '%F' /usr/local/bin/solc | xargs -r strip --strip-unneeded
 
 USER ${USER}
 
 RUN set -xe \
  && mix do local.hex --force, local.rebar --force
-

--- a/builder/Dockerfile.rocksdb
+++ b/builder/Dockerfile.rocksdb
@@ -1,0 +1,43 @@
+FROM alpine:3.8
+
+ARG ROCKSDB_VERSION="6.2.2"
+ARG ROCKSDB_DOWNLOAD_SHA256="3e7365cb2a35982e95e5e5dd0b3352dc78573193dafca02788572318c38483fb"
+
+RUN set -xe \
+ && ROCKSDB_DOWNLOAD_URL="https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VERSION}.tar.gz" \
+ && apk add --update --no-cache --virtual .rocksdb-build \
+        bash \
+        curl \
+        g++ \
+        gcc \
+        linux-headers \
+        make \
+        perl \
+        tar \
+ && curl -fsL -o rocksdb-src.tar.gz "${ROCKSDB_DOWNLOAD_URL}" \
+ && echo "${ROCKSDB_DOWNLOAD_SHA256}  rocksdb-src.tar.gz" |sha256sum -c - \
+ && mkdir -vp /usr/local/src/rocksdb \
+ && tar -xzC /usr/local/src/rocksdb --strip-components=1 -f rocksdb-src.tar.gz \
+ && rm rocksdb-src.tar.gz \
+ && ( \
+        cd /usr/local/src/rocksdb \
+        && make -j$(nproc) shared_lib LITE=1 \
+        && mkdir -p /usr/local/rocksdb/lib \
+        && mkdir -p /usr/local/rocksdb/include \
+        && cp -dr librocksdb.so* /usr/local/rocksdb/lib \
+        && cp -dr include/* /usr/local/rocksdb/include \
+    ) \
+ && rm -rf /usr/local/src/rocksdb \
+ && scanelf --nobanner -E ET_EXEC -BF '%F' --recursive /usr/local/rocksdb | xargs -r strip --strip-all \
+ && scanelf --nobanner -E ET_DYN -BF '%F' --recursive /usr/local/rocksdb | xargs -r strip --strip-unneeded \
+ && ROCKSDB_RUN_DEPS="$( \
+        scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/rocksdb \
+            | tr ',' '\n' \
+            | sort -u \
+            | awk 'system("[ -e /usr/local/rocksdb/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+    )" \
+ && apk add --update --no-cache --virtual .rocksdb-run $ROCKSDB_RUN_DEPS \
+ && apk del .rocksdb-build \
+ && rm -rf /usr/local/src
+
+ENV LD_LIBRARY_PATH=/usr/local/rocksdb/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Patch over #1 

* Split rocksdb build into `Dockerfile.rocksdb` to improve builds caching
* Use `LITE=1` for rocksdb build as we do not need any non-LITE features
* Set `CMAKE_PREFIX_PATH` to `/usr/local/*` so `cmake` could discover `/usr/local/*/lib`
* Strip everything

Result:

```
omisegoimages/elixir-omg-builder           latest              b9880318461e        38 minutes ago      551MB
```