### PR TITLE
bump: plasma-contracts to 1c7cd867

### DIFF
--- a/tester/Dockerfile.plasma_deployer
+++ b/tester/Dockerfile.plasma_deployer
@@ -12,6 +12,6 @@ RUN apk add --update \
 		git
 
 RUN git clone https://github.com/omisego/plasma-contracts.git
-RUN cd /home/node/plasma-contracts && git reset --hard e3c15df7c816770c60d257557c62b1f7105e07c2
+RUN cd /home/node/plasma-contracts && git reset --hard 1c7cd867b1353ae72c825a6d15b2d382689f30ad
 RUN cd /home/node/plasma-contracts && npm install
 RUN cd /home/node/plasma-contracts/plasma_framework && npm install


### PR DESCRIPTION
Bump plasma-contracts to the latest master (`1c7cd867b1353ae72c825a6d15b2d382689f30ad`)

We're using the image tags so this merge to master should not have impact to running environments unless the image tag is explicitly bumped in each project. 

E.g. in `elixir-omg/docker-compose.yml` it's currently fixed to:

```
  plasma-contracts:
    image: omisegoimages/elixir-omg-tester-plasma-deployer:stable-20191105
```