### PR TITLE
fix: cleanup gcloud sdk installer after installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ commands:
             gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
             ### done installing gcloud requirements
+            ### cleanup
+            rm -rf ~/.google-cloud-sdk
             sleep 4m
             # wait until we're UP
             while true; do 


### PR DESCRIPTION
addressing this issue:
```
+ tar zxf gcloud-sdk.tar.gz google-cloud-sdk
+ mv google-cloud-sdk /home/circleci/.google-cloud-sdk
mv: cannot move 'google-cloud-sdk' to '/home/circleci/.google-cloud-sdk/google-cloud-sdk': Directory not empty
```