### PR TITLE
limit wait for json-server uptime check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,11 @@ commands:
             rm -rf ~/.google-cloud-sdk
             sleep 4m
             # wait until we're UP
-            while true; do 
+            for i in {1..60}; do
               if [ "$(curl localhost:8000/contracts)" ]; then 
                 break
               fi; 
+              sleep 1
             done
             # stop geth in docker so that we can snapshot
             docker exec -it $(docker ps -aqf "name=geth") /bin/sh -c "pkill -INT geth"


### PR DESCRIPTION
If the json-server (port 8000) fails to start the while-loop will go on forever and block CI workers until they timeout. This replaces it with a for-loop+sleep that will try for 1 minute to reach the server.