### PR TITLE
fix issue with json-server

### DIFF
--- a/tester/Dockerfile.plasma_deployer
+++ b/tester/Dockerfile.plasma_deployer
@@ -1,4 +1,4 @@
-FROM node:8.16-alpine
+FROM node:10-alpine
 
 MAINTAINER OmiseGO Engineering <info@omisego.co>
 
@@ -9,7 +9,7 @@ RUN apk add --update \
     python-dev \
     py-pip \
     build-base \
-		git
+    git
 
 RUN git clone https://github.com/omisego/plasma-contracts.git
 COPY CONTRACT_SHA /tmp/CONTRACT_SHA


### PR DESCRIPTION
The CI is failing in the "Get Plasma Deployer image and standup geth and deploy contracts" step because the `tester/Dockerfile.plasma_deployer` docker image uses node-8 as a base. One of the package dependencies (json-server) was updated 2 days ago and now requires at least node 10 (https://github.com/typicode/json-server/releases/tag/v0.16.0):

```
/home/node/plasma-contracts/plasma_framework # npx json-server
npx: installed 226 in 25.747s
json-server requires at least version 10 of Node, please upgrade
```

For a quick fix I'm bumping the node version to v10 (same as the one in plasma_contracts)