### PR TITLE
add gcc and musl-dev

### DIFF
--- a/builder/Dockerfile.rust
+++ b/builder/Dockerfile.rust
@@ -2,7 +2,7 @@ FROM alpine:3.11
 
 ARG RUST_VERSION="1.46.0"
 
-RUN RUN apk add --no-cache gcc musl-dev
+RUN apk add --no-cache gcc musl-dev
 
 ADD ./rustup.sh ./rustup.sh
 RUN chmod u+x ./rustup.sh

--- a/builder/Dockerfile.rust
+++ b/builder/Dockerfile.rust
@@ -2,11 +2,12 @@ FROM alpine:3.11
 
 ARG RUST_VERSION="1.46.0"
 
+RUN RUN apk add --no-cache gcc musl-dev
+
 ADD ./rustup.sh ./rustup.sh
 RUN chmod u+x ./rustup.sh
 RUN ./rustup.sh -y
 
 ENV PATH=/root/.cargo/bin:$PATH
-
 RUN rustup toolchain install ${RUST_VERSION}
 RUN rustup default ${RUST_VERSION}

--- a/builder_childchain/Dockerfile
+++ b/builder_childchain/Dockerfile
@@ -23,6 +23,7 @@ ENV PATH=/usr/local/otp/bin:$PATH
 ENV PATH=/usr/local/rebar3/bin:$PATH
 ENV PATH=/usr/local/elixir/bin:$PATH
 ENV PATH=/root/.cargo/bin:$PATH
+
 RUN rustc -V
 
 ENV HOME /home/${USER}

--- a/builder_childchain/Dockerfile
+++ b/builder_childchain/Dockerfile
@@ -23,6 +23,7 @@ ENV PATH=/usr/local/otp/bin:$PATH
 ENV PATH=/usr/local/rebar3/bin:$PATH
 ENV PATH=/usr/local/elixir/bin:$PATH
 ENV PATH=/root/.cargo/bin:$PATH
+RUN rustc -V
 
 ENV HOME /home/${USER}
 ENV LANG=en_US.UTF-8

--- a/builder_childchain/Dockerfile
+++ b/builder_childchain/Dockerfile
@@ -39,6 +39,8 @@ RUN set -xe \
         docker \
         expect \
         findutils \
+        gcc \
+        musl-dev \
         git \
         gnupg \
         libressl \


### PR DESCRIPTION
`rustc` requires `gcc` and `musl-dev ` to be installed